### PR TITLE
fix: update App tests to match TCM content

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,17 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import App from "./App";
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+describe("App Component", () => {
+  test("app renders without crashing", () => {
+    const { container } = render(<App />);
+    expect(container).toBeInTheDocument();
+  });
+
+  test("renders TCM wellness content", () => {
+    render(<App />);
+
+    const tcmElements = screen.queryAllByText(/Traditional Chinese Medicine/i);
+    expect(tcmElements.length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Changes
- Fixed App.test.tsx to match actual TCM wellness content
- Removed default "learn react" test from Create React App
- All tests now passing

## Testing Results
```
Test Suites: 2 passed, 2 total
Tests:       17 passed, 17 total (0 failed)
Time:        1.686s

## Related Issues
- Part of Testing Framework & Execution requirement
- Fixes failing CI tests